### PR TITLE
Block textures

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,8 @@ set(SOURCES
   src/common.c
   src/coords.h
   src/coords.c
+  src/textures.h
+  src/textures.c
   src/world.h
   src/world.c
   src/camera.h

--- a/src/camera.c
+++ b/src/camera.c
@@ -7,6 +7,7 @@
 #include "camera.h"
 #include "common.h"
 #include "coords.h"
+#include "textures.h"
 #include "world.h"
 #include "profiling.h"
 
@@ -264,6 +265,15 @@ void sortBlockFaces(DisplayBlockFaces* faces) {
     }
 }
 
+DisplayCoords findPointInFace(DisplayBlockFace face, double xt, double yt) {
+    int minX = LERP((double)face.vertices[0].x, (double)face.vertices[3].x, yt);
+    int maxX = LERP((double)face.vertices[1].x, (double)face.vertices[2].x, yt);
+    int minY = LERP((double)face.vertices[0].y, (double)face.vertices[1].y, xt);
+    int maxY = LERP((double)face.vertices[3].y, (double)face.vertices[2].y, xt);
+
+    return (DisplayCoords) {LERP(minX, maxX, xt), LERP(minY, maxY, yt), true};
+}
+
 void renderBlockFace(DisplayBlockFace face, color_t colour) {
     drawDisplayTriangle(face.vertices[0], face.vertices[1], face.vertices[2], colour);
     drawDisplayTriangle(face.vertices[0], face.vertices[2], face.vertices[3], colour);
@@ -272,6 +282,12 @@ void renderBlockFace(DisplayBlockFace face, color_t colour) {
     drawDisplayLine(face.vertices[1], face.vertices[2], C_BLACK);
     drawDisplayLine(face.vertices[2], face.vertices[3], C_BLACK);
     drawDisplayLine(face.vertices[3], face.vertices[0], C_BLACK);
+
+    for (unsigned int i = 0; i < textures[face.texture].linesToRender; i++) {
+        TextureLine line = textures[face.texture].lines[i];
+
+        drawDisplayLine(findPointInFace(face, line.x1, line.y1), findPointInFace(face, line.x2, line.y2), C_BLACK);
+    }
 }
 
 void camera_render(Camera camera, World world) {
@@ -343,7 +359,7 @@ void camera_render(Camera camera, World world) {
                 continue;
             }
 
-            DisplayBlockFace faceToAdd = {.z = zSum / zTotal};
+            DisplayBlockFace faceToAdd = {.z = zSum / zTotal, .texture = TEXTURE_TEST};
 
             for (unsigned int i = 0; i < 4; i++) {
                 faceToAdd.vertices[i] = pixelsToSet[FACE_VERTICES[(face * 4) + i]];

--- a/src/camera.c
+++ b/src/camera.c
@@ -275,6 +275,12 @@ DisplayCoords findPointInFace(DisplayBlockFace face, double xt, double yt) {
 }
 
 void renderBlockFace(DisplayBlockFace face, color_t colour) {
+    for (unsigned int i = 0; i < 4; i++) {
+        if (!face.vertices[i].render) {
+            return;
+        }
+    }
+
     drawDisplayTriangle(face.vertices[0], face.vertices[1], face.vertices[2], colour);
     drawDisplayTriangle(face.vertices[0], face.vertices[2], face.vertices[3], colour);
 
@@ -284,6 +290,10 @@ void renderBlockFace(DisplayBlockFace face, color_t colour) {
     drawDisplayLine(face.vertices[3], face.vertices[0], C_BLACK);
 
     if (face.z > 6) { // TODO: Allow rendering distance options via some graphics settings menu
+        return;
+    }
+
+    if (ABS(face.vertices[1].x - face.vertices[0].x) < 8 || ABS(face.vertices[3].y - face.vertices[0].y) < 8) {
         return;
     }
 
@@ -367,7 +377,10 @@ void camera_render(Camera camera, World world) {
                 continue;
             }
 
-            DisplayBlockFace faceToAdd = {.z = zSum / zTotal, .texture = world_getBlockTexture(block.type, faceSide)};
+            DisplayBlockFace faceToAdd = {
+                .z = zSum / zTotal,
+                .texture = world_getBlockTexture(block.type, faceSide)
+            };
 
             for (unsigned int i = 0; i < 4; i++) {
                 faceToAdd.vertices[i] = pixelsToSet[FACE_VERTICES[(face * 4) + i]];

--- a/src/camera.c
+++ b/src/camera.c
@@ -266,12 +266,12 @@ void sortBlockFaces(DisplayBlockFaces* faces) {
 }
 
 DisplayCoords findPointInFace(DisplayBlockFace face, double xt, double yt) {
-    int minX = LERP((double)face.vertices[0].x, (double)face.vertices[3].x, yt);
-    int maxX = LERP((double)face.vertices[1].x, (double)face.vertices[2].x, yt);
-    int minY = LERP((double)face.vertices[0].y, (double)face.vertices[1].y, xt);
-    int maxY = LERP((double)face.vertices[3].y, (double)face.vertices[2].y, xt);
+    int minX = LERP((double)face.vertices[0].x, (double)face.vertices[3].x, yt / 16);
+    int maxX = LERP((double)face.vertices[1].x, (double)face.vertices[2].x, yt / 16);
+    int minY = LERP((double)face.vertices[0].y, (double)face.vertices[1].y, xt / 16);
+    int maxY = LERP((double)face.vertices[3].y, (double)face.vertices[2].y, xt / 16);
 
-    return (DisplayCoords) {LERP(minX, maxX, xt), LERP(minY, maxY, yt), true};
+    return (DisplayCoords) {LERP(minX, maxX, xt / 16), LERP(minY, maxY, yt / 16), true};
 }
 
 void renderBlockFace(DisplayBlockFace face, color_t colour) {
@@ -282,6 +282,10 @@ void renderBlockFace(DisplayBlockFace face, color_t colour) {
     drawDisplayLine(face.vertices[1], face.vertices[2], C_BLACK);
     drawDisplayLine(face.vertices[2], face.vertices[3], C_BLACK);
     drawDisplayLine(face.vertices[3], face.vertices[0], C_BLACK);
+
+    if (face.z > 6) { // TODO: Allow rendering distance options via some graphics settings menu
+        return;
+    }
 
     for (unsigned int i = 0; i < textures[face.texture].linesToRender; i++) {
         TextureLine line = textures[face.texture].lines[i];
@@ -354,12 +358,16 @@ void camera_render(Camera camera, World world) {
         profiling_start(PROFILING_FIND_EDGES);
         #endif
 
+        int faceSide = -1;
+
         for (unsigned int face = 0; face < sizeof(faceStates) / sizeof(faceStates[0]); face++) {
+            faceSide++;
+
             if (!faceStates[face]) {
                 continue;
             }
 
-            DisplayBlockFace faceToAdd = {.z = zSum / zTotal, .texture = TEXTURE_TEST};
+            DisplayBlockFace faceToAdd = {.z = zSum / zTotal, .texture = world_getBlockTexture(block.type, faceSide)};
 
             for (unsigned int i = 0; i < 4; i++) {
                 faceToAdd.vertices[i] = pixelsToSet[FACE_VERTICES[(face * 4) + i]];

--- a/src/camera.h
+++ b/src/camera.h
@@ -2,6 +2,7 @@
 #define CAMERA_H
 
 #include "coords.h"
+#include "textures.h"
 #include "world.h"
 
 #define SWAPCOORDS(a, b) {DisplayCoords temp = a; a = b; b = temp;}
@@ -30,6 +31,7 @@ typedef struct {
 typedef struct {
     DisplayCoords vertices[4];
     double z;
+    int texture;
 } DisplayBlockFace;
 
 typedef struct {

--- a/src/main.c
+++ b/src/main.c
@@ -5,6 +5,7 @@
 
 #include "flags.h"
 #include "common.h"
+#include "textures.h"
 #include "world.h"
 #include "camera.h"
 #include "profiling.h"
@@ -35,6 +36,8 @@ void showProfile() {
 
 void main() {
 	bool showLogo = true;
+
+	textures_init();
 
 	World world = world_default();
 	Camera camera = camera_default();

--- a/src/main.c
+++ b/src/main.c
@@ -57,7 +57,7 @@ void main() {
 
 	world_addBlock(&world, (Block) {
 		.position = (CartesianVector) {1, 1, 1},
-		.type = BLOCK_TYPE_STONE
+		.type = BLOCK_TYPE_WOOD
 	});
 
 	#ifdef FLAG_PROFILING

--- a/src/main.c
+++ b/src/main.c
@@ -46,18 +46,28 @@ void main() {
 	camera.position.y = 1;
 	camera.position.z = 1;
 
+	world_addBlock(&world, (Block) {
+		.position = (CartesianVector) {1, 0, 1},
+		.type = BLOCK_TYPE_WOOD
+	});
+
+	world_addBlock(&world, (Block) {
+		.position = (CartesianVector) {1, 1, 1},
+		.type = BLOCK_TYPE_WOOD
+	});
+
 	for (unsigned int x = 0; x < 3; x++) {
 		for (unsigned int z = 0; z < 3; z++) {
 			world_addBlock(&world, (Block) {
-				.position = (CartesianVector) {x, 0, z},
-				.type = BLOCK_TYPE_STONE
+				.position = (CartesianVector) {x, 2, z},
+				.type = BLOCK_TYPE_LEAVES
 			});
 		}
 	}
 
 	world_addBlock(&world, (Block) {
-		.position = (CartesianVector) {1, 1, 1},
-		.type = BLOCK_TYPE_WOOD
+		.position = (CartesianVector) {1, 3, 1},
+		.type = BLOCK_TYPE_LEAVES
 	});
 
 	#ifdef FLAG_PROFILING

--- a/src/textures.c
+++ b/src/textures.c
@@ -31,10 +31,10 @@ void textures_init() {
     textures[TEXTURE_WOOD].lines[6] = (TextureLine) {14, 0, 14, 16};
     textures[TEXTURE_WOOD].linesToRender = 7;
 
-    textures[TEXTURE_WOOD].lines[0] = (TextureLine) {0, 0, 6, 12};
-    textures[TEXTURE_WOOD].lines[1] = (TextureLine) {3, 5, 16, 2};
-    textures[TEXTURE_WOOD].lines[2] = (TextureLine) {10, 3, 13, 13};
-    textures[TEXTURE_WOOD].lines[3] = (TextureLine) {0, 11, 16, 14};
-    textures[TEXTURE_WOOD].lines[4] = (TextureLine) {8, 13, 5, 16};
-    textures[TEXTURE_WOOD].linesToRender = 7;
+    textures[TEXTURE_LEAVES] = textures[TEXTURE_LEAVES];
+
+    textures[TEXTURE_LEAVES].lines[0] = (TextureLine) {0, 0, 16, 16};
+    textures[TEXTURE_LEAVES].lines[1] = (TextureLine) {0, 10, 10, 0};
+    textures[TEXTURE_LEAVES].lines[2] = (TextureLine) {10, 16, 16, 10};
+    textures[TEXTURE_LEAVES].linesToRender = 3;
 }

--- a/src/textures.c
+++ b/src/textures.c
@@ -1,0 +1,21 @@
+#include "textures.h"
+
+Texture textures[TEXTURE_COUNT];
+
+Texture textures_default() {
+    Texture texture = {.linesToRender = 0};
+
+    for (unsigned int i = 0; i < LINES_PER_TEXTURE; i++) {
+        texture.lines[i] = (TextureLine) {0, 0, 0, 0};
+    }
+
+    return texture;
+}
+
+void textures_init() {
+    textures[TEXTURE_TEST] = textures_default();
+
+    textures[TEXTURE_TEST].lines[0] = (TextureLine) {1, 1, 15, 15};
+    textures[TEXTURE_TEST].lines[1] = (TextureLine) {15, 1, 1, 15};
+    textures[TEXTURE_TEST].linesToRender = 2;
+}

--- a/src/textures.c
+++ b/src/textures.c
@@ -13,9 +13,28 @@ Texture textures_default() {
 }
 
 void textures_init() {
-    textures[TEXTURE_TEST] = textures_default();
+    textures[TEXTURE_DEFAULT] = textures_default();
 
-    textures[TEXTURE_TEST].lines[0] = (TextureLine) {1, 1, 15, 15};
-    textures[TEXTURE_TEST].lines[1] = (TextureLine) {15, 1, 1, 15};
-    textures[TEXTURE_TEST].linesToRender = 2;
+    textures[TEXTURE_GRASS] = textures[TEXTURE_DEFAULT];
+
+    textures[TEXTURE_GRASS].lines[0] = (TextureLine) {0, 3, 16, 3};
+    textures[TEXTURE_GRASS].linesToRender = 1;
+
+    textures[TEXTURE_WOOD] = textures[TEXTURE_DEFAULT];
+
+    textures[TEXTURE_WOOD].lines[0] = (TextureLine) {2, 0, 2, 16};
+    textures[TEXTURE_WOOD].lines[1] = (TextureLine) {5, 0, 5, 5};
+    textures[TEXTURE_WOOD].lines[2] = (TextureLine) {5, 8, 5, 16};
+    textures[TEXTURE_WOOD].lines[3] = (TextureLine) {8, 0, 8, 16};
+    textures[TEXTURE_WOOD].lines[4] = (TextureLine) {11, 0, 11, 11};
+    textures[TEXTURE_WOOD].lines[5] = (TextureLine) {11, 14, 11, 16};
+    textures[TEXTURE_WOOD].lines[6] = (TextureLine) {14, 0, 14, 16};
+    textures[TEXTURE_WOOD].linesToRender = 7;
+
+    textures[TEXTURE_WOOD].lines[0] = (TextureLine) {0, 0, 6, 12};
+    textures[TEXTURE_WOOD].lines[1] = (TextureLine) {3, 5, 16, 2};
+    textures[TEXTURE_WOOD].lines[2] = (TextureLine) {10, 3, 13, 13};
+    textures[TEXTURE_WOOD].lines[3] = (TextureLine) {0, 11, 16, 14};
+    textures[TEXTURE_WOOD].lines[4] = (TextureLine) {8, 13, 5, 16};
+    textures[TEXTURE_WOOD].linesToRender = 7;
 }

--- a/src/textures.h
+++ b/src/textures.h
@@ -2,10 +2,13 @@
 #define TEXTURES_H_
 
 #define LINES_PER_TEXTURE 8
-#define TEXTURE_COUNT 1
+#define TEXTURE_COUNT 5
 
 enum {
-    TEXTURE_TEST
+    TEXTURE_DEFAULT,
+    TEXTURE_GRASS,
+    TEXTURE_WOOD,
+    TEXTURE_LEAVES
 };
 
 typedef struct {

--- a/src/textures.h
+++ b/src/textures.h
@@ -1,0 +1,28 @@
+#ifndef TEXTURES_H_
+#define TEXTURES_H_
+
+#define LINES_PER_TEXTURE 8
+#define TEXTURE_COUNT 1
+
+enum {
+    TEXTURE_TEST
+};
+
+typedef struct {
+    int x1;
+    int y1;
+    int x2;
+    int y2;
+} TextureLine;
+
+typedef struct {
+    TextureLine lines[LINES_PER_TEXTURE];
+    unsigned int linesToRender;
+} Texture;
+
+extern Texture textures[TEXTURE_COUNT];
+
+Texture textures_default();
+void textures_init();
+
+#endif

--- a/src/world.c
+++ b/src/world.c
@@ -2,6 +2,13 @@
 
 #include "world.h"
 #include "coords.h"
+#include "textures.h"
+
+const int BLOCK_INFO[] = {
+    // Block type, texture 0-5
+    BLOCK_TYPE_WOOD, TEXTURE_WOOD, TEXTURE_WOOD, TEXTURE_DEFAULT, TEXTURE_DEFAULT, TEXTURE_WOOD, TEXTURE_WOOD,
+    BLOCK_TYPE_LEAVES, TEXTURE_LEAVES, TEXTURE_LEAVES, TEXTURE_LEAVES, TEXTURE_LEAVES, TEXTURE_LEAVES, TEXTURE_LEAVES
+};
 
 CartesianVector* world_getBlockVertices(Block block) {
     CartesianVector* vertices = malloc(8 * sizeof(CartesianVector));
@@ -44,4 +51,14 @@ Block world_getBlock(World world, CartesianVector position) {
         .position = position,
         .type = BLOCK_TYPE_AIR
     };
+}
+
+int world_getBlockTexture(int blockType, int face) {
+    for (unsigned int i = 0; i < sizeof(BLOCK_INFO) / sizeof(BLOCK_INFO[0]); i += 7) {
+        if (BLOCK_INFO[i] == blockType) {
+            return BLOCK_INFO[i + face];
+        }
+    }
+
+    return TEXTURE_DEFAULT;
 }

--- a/src/world.c
+++ b/src/world.c
@@ -56,7 +56,7 @@ Block world_getBlock(World world, CartesianVector position) {
 int world_getBlockTexture(int blockType, int face) {
     for (unsigned int i = 0; i < sizeof(BLOCK_INFO) / sizeof(BLOCK_INFO[0]); i += 7) {
         if (BLOCK_INFO[i] == blockType) {
-            return BLOCK_INFO[i + face];
+            return BLOCK_INFO[i + face + 1];
         }
     }
 

--- a/src/world.h
+++ b/src/world.h
@@ -5,7 +5,13 @@
 
 enum {
     BLOCK_TYPE_AIR = 0,
-    BLOCK_TYPE_STONE = 1
+    BLOCK_TYPE_STONE = 1,
+    BLOCK_TYPE_GRASS = 2,
+    BLOCK_TYPE_DIRT = 3,
+    BLOCK_TYPE_COBBLESTONE = 4,
+    BLOCK_TYPE_PLANK = 5,
+    BLOCK_TYPE_WOOD = 17,
+    BLOCK_TYPE_LEAVES = 18
 };
 
 typedef struct {
@@ -23,5 +29,7 @@ CartesianVector* world_getBlockVertices(Block block);
 World world_default();
 void world_addBlock(World* world, Block block);
 Block world_getBlock(World world, CartesianVector position);
+
+int world_getBlockTexture(int blockType, int face);
 
 #endif


### PR DESCRIPTION
This pull request adds simple textures to blocks based on their block type. Textures are implemented as lines which are drawn on the faces of blocks, and up to 8 lines can be drawn per face. Each face of a given block may have its own unique texture (such as four of the six faces of a wood block having a striped pattern).

Since rendering textures can be slow, two conditions must be satisfied for a texture to be rendered on a visible block:
* The camera must be about 6 blocks close to the face
* The face must be sufficiently oriented towards the camera — faces which are barely visible are not worth rendering due to their slimness

Currently, only textures for a few block faces have been made.