### PR TITLE
Fix minor navigation issue in inventory

### DIFF
--- a/src/inventory.c
+++ b/src/inventory.c
@@ -138,7 +138,7 @@ void inventory_open(Inventory* inventory) {
                 break;
         }
 
-        while (selectedSlot > SLOTS_IN_INVENTORY) {
+        while (selectedSlot >= SLOTS_IN_INVENTORY) {
             selectedSlot -= SLOTS_IN_ROW;
         }
 


### PR DESCRIPTION
This PR fixes the issue of the up arrow key in the inventory causing an invalid slot to be selected. Had this not been fixed, there would be issues with moving items to the invalid slot later on.