### PR TITLE
Remove redundant checks for inventory slot selection

### DIFF
--- a/src/inventory.c
+++ b/src/inventory.c
@@ -171,14 +171,6 @@ void inventory_open(Inventory* inventory) {
                 inventory_handleSelection(key, &selectedSlot);
                 break;
         }
-
-        while (selectedSlot >= SLOTS_IN_INVENTORY) {
-            selectedSlot -= SLOTS_IN_ROW;
-        }
-
-        while (selectedSlot < 0) {
-            selectedSlot += SLOTS_IN_ROW;
-        }
     }
 
     closeInventory:


### PR DESCRIPTION
Since out-of-bounds checks for inventory slot selection were moved to `inventory_handleSelection`, the checks in `inventory_open` have been made redundant. This PR removes those redundant checks from `inventory_open`.