### PR TITLE
Tool usage with block destruction

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,8 @@ set(SOURCES
     src/common.c
     src/coords.h
     src/coords.c
+    src/ui.h
+    src/ui.c
     src/textures.h
     src/textures.c
     src/world.h

--- a/src/common.h
+++ b/src/common.h
@@ -8,8 +8,8 @@
 #define ABS(x) ((x) < 0 ? -(x) : (x))
 #define MIN(a, b) ((a) < (b) ? (a) : (b))
 #define MAX(a, b) ((a) > (b) ? (a) : (b))
-#define LERP(v0, v1, t) ((v0 * (1 - t)) + (v1 * t))
-#define INVLERP(v0, v1, v) ((v - v0) / (v1 - v0))
+#define LERP(v0, v1, t) (((v0) * (1 - (t))) + ((v1) * (t)))
+#define INVLERP(v0, v1, v) (((v) - (v0)) / ((v1) - (v0)))
 #define SWAPINT(a, b) {int temp = a; a = b; b = temp;}
 #define MSEC * 1000
 #define SEC MSEC * 1000

--- a/src/common.h
+++ b/src/common.h
@@ -11,6 +11,8 @@
 #define LERP(v0, v1, t) ((v0 * (1 - t)) + (v1 * t))
 #define INVLERP(v0, v1, v) ((v - v0) / (v1 - v0))
 #define SWAPINT(a, b) {int temp = a; a = b; b = temp;}
+#define MSEC * 1000
+#define SEC MSEC * 1000
 
 int common_degrees(double rad);
 double common_radians(int deg);

--- a/src/inventory.h
+++ b/src/inventory.h
@@ -15,7 +15,8 @@ enum {
 };
 
 enum {
-    GAME_MODE_SURVIVAL = 0
+    GAME_MODE_SURVIVAL = 0,
+    GAME_MODE_CREATIVE = 1
 };
 
 typedef struct {

--- a/src/items.c
+++ b/src/items.c
@@ -1,6 +1,7 @@
 #include <gint/display.h>
 #include <gint/display-fx.h>
 
+#include "common.h"
 #include "items.h"
 #include "world.h"
 
@@ -45,6 +46,32 @@ void items_init() {
 
 bool items_isPlaceable(int blockType) {
     return blockType < 256;
+}
+
+bool items_isTool(int itemType) {
+    switch (itemType) {
+        case ITEM_TYPE_WOODEN_AXE: return true;
+        default: return false;
+    }
+}
+
+int items_getDestructionTime(int blockType, int toolItemType) {
+    switch (blockType) {
+        case BLOCK_TYPE_LEAVES: return 100 MSEC;
+
+        case BLOCK_TYPE_WOOD:
+        case BLOCK_TYPE_PLANK:
+            if (toolItemType == ITEM_TYPE_WOODEN_AXE) return 300 MSEC;
+
+            return 1 SEC;
+
+        case BLOCK_TYPE_CRAFTING_TABLE:
+            if (toolItemType == ITEM_TYPE_WOODEN_AXE) return 600 MSEC;
+
+            return 2 SEC;
+
+        default: return 500 MSEC;
+    }
 }
 
 char* items_getItemName(int blockType) {

--- a/src/items.h
+++ b/src/items.h
@@ -12,6 +12,9 @@ extern unsigned int items_thumbnailMappings[THUMBNAILS_COUNT];
 void items_init();
 
 bool items_isPlaceable(int blockType);
+bool items_isTool(int itemType);
+int items_getDestructionTime(int blockType, int toolItemType);
+
 char* items_getItemName(int blockType);
 char* items_getItemNameShort(int blockType);
 

--- a/src/ui.c
+++ b/src/ui.c
@@ -1,0 +1,18 @@
+#include <gint/display.h>
+#include <gint/display-fx.h>
+
+#include "common.h"
+
+void ui_progressBar(int x1, int y1, int x2, int y2, double value) {
+    if (value < 0) {
+        value = 0;
+    }
+
+    if (value > 1) {
+        value = 1;
+    }
+
+    drect_border(x1, y1, x2, y2, C_WHITE, 1, C_BLACK);
+
+    drect(x1 + 2, y1 + 2, LERP(x1 + 2, x2 - 2, value), y2 - 2, C_BLACK);
+}

--- a/src/ui.h
+++ b/src/ui.h
@@ -1,0 +1,6 @@
+#ifndef UI_H_
+#define UI_H_
+
+void ui_progressBar(int x1, int y1, int x2, int y2, double value);
+
+#endif


### PR DESCRIPTION
This PR adds an important game mechanic of Survival Mode. It adds a delay to destroying blocks which can be decreased by using suitable tools for destroying a certain type of block.

When destroying blocks, a progress bar is shown in the top-right corner to show the progress of block destruction. This is similar to the mechanics of the 'cracking' animation in Minecraft, and the inverted radial progress bar shown in Minecraft PE.

This PR also prevents the accidental double-placement of blocks by adding a short cooldown/debounce delay, and also creates `ui.h` and `ui.c`, ready for the creation of other UI controls.