### PR TITLE
World saves

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -634,6 +634,7 @@ void worldMenu() {
             case INPUT_CHOICE_CONFIRM:
                 strcpy(worldName, "Test"); // TODO: Add world name choice
 
+                newWorld();
                 startGame();
                 saveWorld();
 

--- a/src/main.c
+++ b/src/main.c
@@ -168,6 +168,20 @@ void stopKeypressTimer() {
     timer_stop(keypressTimer);
 }
 
+void loadWorld() {
+    ui_message("Loading world:", worldName, "", "Please wait...");
+
+    dupdate();
+
+    WorldSave worldSave = world_load(worldName);
+
+    candidateCamera.position = worldSave.initialCameraPosition;
+    candidateCamera.heading = worldSave.initialCameraHeading;
+
+    inventory = worldSave.inventory;
+    world = worldSave.world;
+}
+
 void saveWorld() {
     ui_message("Saving world:", worldName, "", "Please wait...");
 
@@ -178,6 +192,7 @@ void saveWorld() {
     worldSave.initialCameraPosition = candidateCamera.position;
     worldSave.initialCameraHeading = candidateCamera.heading;
 
+    worldSave.inventory = inventory;
     worldSave.world = world;
 
     int status = world_save(worldSave, worldName);
@@ -388,11 +403,8 @@ bool pauseMenu(bool renderOnly) {
     }
 }
 
-void startGame() {
+void newWorld() {
     world = world_default();
-    Camera camera;
-    PhysicsSimulation sim = physics_default(&candidateCamera, &world);
-
     candidateCamera = camera_default();
     inventory = inventory_default();
 
@@ -428,6 +440,11 @@ void startGame() {
     inventory.slots[0].count = MAX_COUNT_IN_SLOT;
     inventory.slots[1].type = BLOCK_TYPE_GRASS;
     inventory.slots[1].count = MAX_COUNT_IN_SLOT;
+}
+
+void startGame() {
+    Camera camera;
+    PhysicsSimulation sim = physics_default(&candidateCamera, &world);
 
     startKeypressTimer();
 
@@ -595,6 +612,14 @@ void worldMenu() {
             case INPUT_CHOICE_FN:
                 if (ui_getFnKey() == 1 || ui_getFnKey() == 3) { // TODO: Make these keys perform different actions once world storage is done
                     strcpy(worldName, "Test"); // TODO: Add world name choice
+
+                    if (ui_getFnKey() == 1) {
+                        loadWorld();
+                    }
+
+                    if (ui_getFnKey() == 3) {
+                        newWorld();
+                    }
 
                     startGame();
                     saveWorld();

--- a/src/world.h
+++ b/src/world.h
@@ -7,6 +7,7 @@
 #define MAX_WORLD_NAME_LENGTH 8
 #define WORLD_FILE_PATH_BASE "\\\\fls0\\"
 #define WORLD_FILE_PATH_EXT ".scw"
+#define MAX_WORLD_SIZE 16 * 1024 // 16 KiB - when changing this, update error message too
 
 enum {
     BLOCK_TYPE_AIR = 0,
@@ -20,6 +21,13 @@ enum {
     BLOCK_TYPE_CRAFTING_TABLE = 58,
     ITEM_TYPE_WOODEN_AXE = 271,
     ITEM_TYPE_STICK = 280
+};
+
+enum {
+    WORLD_SAVE_SUCCESS = 0,
+    WORLD_SAVE_CANNOT_LOAD = -1,
+    WORLD_SAVE_TOO_BIG = -2,
+    WORLD_SAVE_NEWER_THAN_EXPECTED = -3
 };
 
 typedef struct {
@@ -40,6 +48,11 @@ typedef struct {
     World world;
 } WorldSave;
 
+typedef struct {
+    int status;
+    WorldSave worldSave;
+} WorldSaveStatus;
+
 CartesianVector* world_getBlockVertices(Block block);
 
 World world_default();
@@ -52,7 +65,7 @@ unsigned int world_getSaveSize(WorldSave worldSave);
 
 int world_getBlockTexture(int blockType, int face);
 
-WorldSave world_load(char* name);
+WorldSaveStatus world_load(char* name);
 int world_save(WorldSave worldSave, char* name);
 
 #endif

--- a/src/world.h
+++ b/src/world.h
@@ -2,6 +2,7 @@
 #define WORLD_H_
 
 #include "coords.h"
+#include "inventory.h"
 
 #define MAX_WORLD_NAME_LENGTH 8
 #define WORLD_FILE_PATH_BASE "\\\\fls0\\"
@@ -35,6 +36,7 @@ typedef struct {
     unsigned int vernum;
     CartesianVector initialCameraPosition;
     PolarVector initialCameraHeading;
+    Inventory inventory;
     World world;
 } WorldSave;
 


### PR DESCRIPTION
This PR adds the ability to save and load worlds to and from the flash memory of the calculator. The worlds are saved as single files with the file extension `scw`.

Currently (because the world list and new world menu don't exist yet), the world `Test.scw` is loaded when <kbd>F1</kbd> is pressed on the **Select World** menu. Pressing <kbd>F3</kbd> creates a new world, overwriting `Test.scw`. Upon choosing the option **Save & Quit**, the current world is saved.